### PR TITLE
TE-7667 Fixed Elasticsearch auth header checks to correctly handle falsy values

### DIFF
--- a/src/Spryker/Client/Search/SearchConfig.php
+++ b/src/Spryker/Client/Search/SearchConfig.php
@@ -47,8 +47,9 @@ class SearchConfig extends AbstractBundleConfig
         $config['port'] = $this->get(SearchConstants::ELASTICA_PARAMETER__PORT);
         $config['host'] = $this->get(SearchConstants::ELASTICA_PARAMETER__HOST);
 
-        $authHeader = $this->get(SearchConstants::ELASTICA_PARAMETER__AUTH_HEADER, null);
-        if ($authHeader !== null) {
+        $authHeader = (string)$this->get(SearchConstants::ELASTICA_PARAMETER__AUTH_HEADER, '');
+
+        if ($authHeader !== '') {
             $config['headers'] = [
                 'Authorization' => 'Basic ' . $authHeader,
             ];

--- a/src/Spryker/Shared/Search/Provider/AbstractSearchClientProvider.php
+++ b/src/Spryker/Shared/Search/Provider/AbstractSearchClientProvider.php
@@ -41,9 +41,11 @@ abstract class AbstractSearchClientProvider extends AbstractClientProvider
         $config['port'] = Config::get(SearchConstants::ELASTICA_PARAMETER__PORT);
         $config['host'] = Config::get(SearchConstants::ELASTICA_PARAMETER__HOST);
 
-        if (Config::hasValue(SearchConstants::ELASTICA_PARAMETER__AUTH_HEADER)) {
+        $authHeader = (string)Config::get(SearchConstants::ELASTICA_PARAMETER__AUTH_HEADER, '');
+
+        if ($authHeader !== '') {
             $config['headers'] = [
-                'Authorization' => 'Basic ' . Config::get(SearchConstants::ELASTICA_PARAMETER__AUTH_HEADER),
+                'Authorization' => 'Basic ' . $authHeader,
             ];
         }
 


### PR DESCRIPTION
#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Search                | patch                 |                       |

-----------------------------------------

#### Module Search

##### Change log

Fixes

- Fixed Elasticsearch auth header checks to correctly handle falsy values.

